### PR TITLE
changed faq entry from MIT form to Tufts form

### DIFF
--- a/index.html
+++ b/index.html
@@ -135,7 +135,7 @@ you're quite the l33t hacker looking at this page's source
 					</div>
 					<div class="col-md-4">
 						<h3 class="question">How do teams work?</h3>
-						<p class="answer">Teams are at most 4 people. You could have designated teammates when you registered, or you could have also registered individually. We ran the lottery by teams, so either your whole team received admission or none of your team received admission (except for automatically admitted MIT students). </p>
+						<p class="answer">Hackathons are more fun when you work with others, so we encourage people to form teams beforehand or find teams at the event. However, prizes will be awarded to projects, not people, so the bigger your team is, the more difficult it will be to split up any awards.</p>
 					</div>
 					<div class="col-md-4">
 						<h3 class="question">What if I don’t have a team?</h3>


### PR DESCRIPTION
The teams entry was identical to the MIT rules, including references to MIT as the organizing body. 
